### PR TITLE
Change srl_generator_v5.js to support different sizes

### DIFF
--- a/bingosync-app/generators/generator_bases/srl_generator_v5.js
+++ b/bingosync-app/generators/generator_bases/srl_generator_v5.js
@@ -71,7 +71,7 @@ bingoGenerator = function(bingoList, opts) {
     var MODE = opts.mode || "normal";
     var cardType = "Normal";
     var SEED = opts.seed || Math.ceil(999999 * Math.random()).toString();
-    var size = 5;
+    var size = opts.size || 5;
 
     // The original SRL generators were written with 1-indexed difficuty tiers.
     // If we get a goal list that is 0-indexed, hack it to be 1-indexed instead.
@@ -80,38 +80,57 @@ bingoGenerator = function(bingoList, opts) {
         bingoList = [undefined].concat(originalBingoList);  // filler value for index 0
     }
 
+    function range(n) {
+        return [...Array(n)].map((_, index) => index);
+    }
+
+    function ij2idx(n,row,col) {
+        return row * n + col;
+    }
+    function siblings(n,row,col) {
+        let out = range(n).filter(i => i != col).map(i => ij2idx(n, row, i));
+        let tmp = range(n).filter(i => i != row).map(i => ij2idx(n, i, col));
+        out.push(...tmp);
+        if(n % 2 == 0) {
+            return out;
+        }
+        // Diagonal Down Left to Right
+        if(row == col) {
+            let tmp = range(n).filter(i=> i != row).map(i => ij2idx(n,i,i));
+            out.push(...tmp);
+        }
+        // Diagonal Down Right to Left
+        let rl = range(n).map(i => ij2idx(n, n-i-1, i));
+        let n2 = Math.floor(n/2);
+        let k0 = ij2idx(n,row,col);
+        if(rl.includes(k0)) {
+            // Include the center square
+            if(row == n2 && col == n2) {
+                out.push(...rl);
+            } else {
+                let tmp = rl.filter(i => i != k0);
+                out.push(... tmp );
+            }
+        }
+        return out;
+    }
+    // Checklist is made up of common rows, columns, or diagonals (only for odd sizes)
+    function makeCheckList(n) {
+        let out = [[]];
+        for(let i = 0; i < n; i++) {
+            for(let j = 0; j < n; j++) {
+                let sib = siblings(n, i, j);
+                out.push(sib);
+            }
+        }
+        return out;
+    }
+
     if (true) {
         Math.seedrandom(SEED);
-        var MAX_SEED = 999999;
+        var MAX_SEED = 999_999;
 
-        var lineCheckList = [];
-        if (size == 5) {
-            lineCheckList[1] = [1, 2, 3, 4, 5, 10, 15, 20, 6, 12, 18, 24];
-            lineCheckList[2] = [0, 2, 3, 4, 6, 11, 16, 21];
-            lineCheckList[3] = [0, 1, 3, 4, 7, 12, 17, 22];
-            lineCheckList[4] = [0, 1, 2, 4, 8, 13, 18, 23];
-            lineCheckList[5] = [0, 1, 2, 3, 8, 12, 16, 20, 9, 14, 19, 24];
-            lineCheckList[6] = [0, 10, 15, 20, 6, 7, 8, 9];
-            lineCheckList[7] = [0, 12, 18, 24, 5, 7, 8, 9, 1, 11, 16, 21];
-            lineCheckList[8] = [5, 6, 8, 9, 2, 12, 17, 22];
-            lineCheckList[9] = [4, 12, 16, 20, 9, 7, 6, 5, 3, 13, 18, 23];
-            lineCheckList[10] = [4, 14, 19, 24, 8, 7, 6, 5];
-            lineCheckList[11] = [0, 5, 15, 20, 11, 12, 13, 14];
-            lineCheckList[12] = [1, 6, 16, 21, 10, 12, 13, 14];
-            lineCheckList[13] = [0, 6, 12, 18, 24, 20, 16, 8, 4, 2, 7, 17, 22, 10, 11, 13, 14];
-            lineCheckList[14] = [3, 8, 18, 23, 10, 11, 12, 14];
-            lineCheckList[15] = [4, 9, 19, 24, 10, 11, 12, 13];
-            lineCheckList[16] = [0, 5, 10, 20, 16, 17, 18, 19];
-            lineCheckList[17] = [15, 17, 18, 19, 1, 6, 11, 21, 20, 12, 8, 4];
-            lineCheckList[18] = [15, 16, 18, 19, 2, 7, 12, 22];
-            lineCheckList[19] = [15, 16, 17, 19, 23, 13, 8, 3, 24, 12, 6, 0];
-            lineCheckList[20] = [4, 9, 14, 24, 15, 16, 17, 18];
-            lineCheckList[21] = [0, 5, 10, 15, 16, 12, 8, 4, 21, 22, 23, 24];
-            lineCheckList[22] = [20, 22, 23, 24, 1, 6, 11, 16];
-            lineCheckList[23] = [2, 7, 12, 17, 20, 21, 23, 24];
-            lineCheckList[24] = [20, 21, 22, 24, 3, 8, 13, 18];
-            lineCheckList[25] = [0, 6, 12, 18, 20, 21, 22, 23, 19, 14, 9, 4];
-        }
+        var lineCheckList = makeCheckList(size);
 
         function mirror(i) {
             if (i == 0) {
@@ -191,12 +210,12 @@ bingoGenerator = function(bingoList, opts) {
             return synergy;
         }
         var bingoBoard = [];
-        for (var i = 1; i <= 25; i++) {
+        for (var i = 1; i <= size * size; i++) {
             bingoBoard[i] = {
                 difficulty: difficulty(i)
             };
         }
-        for (var i = 1; i <= 25; i++) {
+        for (var i = 1; i <= size * size; i++) {
             var getDifficulty = bingoBoard[i].difficulty;
             var RNG = Math.floor(bingoList[getDifficulty].length * Math.random());
             if (RNG == bingoList[getDifficulty].length) {


### PR DESCRIPTION
Change srl_generator_v5.js to support different sizes.

Bingo board size of 5 is still the default.

The primary mnodification here is the construction of the `lineCheckList` variable. This is now done through the `makeCheckList` function. Diagonals are only used in odd-sized tables.

This was checked for a board size of 5 for the Normal Zelda BotW bingo for the first 1,000,000 seeds; max seed is 999,999 but it is never checked.

More tests were done that confirms the time to complete a row, column or diagonal increased with increases with board size.   Plots of this data are in the botw-bingosync-dev discord channel. 